### PR TITLE
Suggest using `--help` if command-line args are missing

### DIFF
--- a/pictureshow/cli.py
+++ b/pictureshow/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from pathlib import Path
 
 from . import __version__
@@ -73,6 +74,12 @@ def main():
         epilog='https://pypi.org/project/pictureshow/'
     )
     parser.version = __version__
+
+    # handle special case before parsing args
+    if not sys.argv[1:]:
+        parser.print_usage(file=sys.stderr)
+        parser.exit(2, "Try 'pictureshow --help' for more information.\n")
+
     args = get_args(parser)
 
     picture_paths = args.pictures

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -245,6 +245,14 @@ class TestCommandLine:
         assert 'error: argument -v' in std_err
         assert 'not allowed with argument -q' in std_err
 
+    def test_special_message_if_args_missing(self, app_exec):
+        command = app_exec
+        proc = subprocess.run(command.split(), stderr=subprocess.PIPE)  # nosec: B603
+        std_err = proc.stderr.decode()
+
+        assert proc.returncode == 2
+        assert "Try 'pictureshow --help' for more information." in std_err
+
 
 class TestPdfSuffix:
     """Test handling of the output file's suffix."""


### PR DESCRIPTION
Close #5