### PR TITLE
Update the `build` step in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -43,7 +43,6 @@ jobs:
       if: matrix.python-version == '3.12'
 
     - name: Build
-      if: matrix.python-version == '3.12' && startsWith(github.ref, 'refs/tags/')
       run: |
         curl -sSL https://install.python-poetry.org | python -
         poetry build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,8 +44,8 @@ jobs:
 
     - name: Build
       run: |
-        curl -sSL https://install.python-poetry.org | python -
-        poetry build
+        pip install build
+        python -m build
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Make the `build` step in GitHub Actions unconditional to catch potential build issues in different Python versions.

Use `build` as the build front-end instead of installing Poetry and running `poetry build`.