### PR TITLE
Refactor function signatures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,10 @@ Example:
 
     from pictureshow import PictureShow
 
-    pictures = PictureShow('pics/cucumber.jpg', 'pics/onion.jpg')
+    pictures = PictureShow(
+        'pics/cucumber.jpg',
+        'pics/onion.jpg',
+    )
     pictures.save_pdf('vegetables.pdf')
 
 The keyword parameters of the ``save_pdf`` method and their default values
@@ -136,7 +139,11 @@ Example:
 
     from pictureshow import pictures_to_pdf
 
-    pictures_to_pdf('pics/cucumber.jpg', 'pics/onion.jpg', output_file='vegetables.pdf')
+    pictures_to_pdf(
+        'pics/cucumber.jpg',
+        'pics/onion.jpg',
+        output_file='vegetables.pdf',
+    )
 
 (Please note that contrary to the ``PictureShow.save_pdf`` method, ``output_file``
 must be specified as a keyword argument in the above example, because the

--- a/README.rst
+++ b/README.rst
@@ -113,13 +113,14 @@ Example:
     )
     pictures.save_pdf('vegetables.pdf')
 
-The keyword parameters of the ``save_pdf`` method and their default values
-correspond to the above shown command line options:
+The customization parameters of the ``save_pdf`` method are keyword-only and
+their default values correspond to the above shown command line options:
 
 .. code-block:: python
 
     PictureShow.save_pdf(
         output_file,
+        *,
         page_size='A4',
         landscape=False,
         margin=72,
@@ -149,8 +150,8 @@ Example:
 must be specified as a keyword argument in the above example, because the
 ``pictures_to_pdf`` function treats all positional arguments as input files.)
 
-The keyword parameters of the ``pictures_to_pdf`` function and their
-default values correspond to the above shown command line options:
+The customization parameters of the ``pictures_to_pdf`` function are keyword-only
+and their default values correspond to the above shown command line options:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ correspond to the above shown command line options:
         layout=(1, 1),
         stretch_small=False,
         fill_area=False,
-        force_overwrite=False
+        force_overwrite=False,
     )
 
 
@@ -156,7 +156,7 @@ default values correspond to the above shown command line options:
         layout=(1, 1),
         stretch_small=False,
         fill_area=False,
-        force_overwrite=False
+        force_overwrite=False,
     )
 
 

--- a/changelog.d/20231203_234025_michalportes1_functions.md
+++ b/changelog.d/20231203_234025_michalportes1_functions.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- Library API: the `page_size`, `landscape`, `margin`, `layout`, `stretch_small`, `fill_area` and `force_overwrite`
+  parameters to `PictureShow.save_pdf` are now keyword-only
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/pictureshow/cli.py
+++ b/src/pictureshow/cli.py
@@ -9,43 +9,93 @@ from .core import PAGE_SIZES, PictureShow
 
 
 def get_args(parser):
-    parser.add_argument('pictures', nargs='+', metavar='PICTURE',
-                        help='one or more picture paths or URLs')
-    parser.add_argument('-a', '--fill-area', action='store_true',
-                        help="fill drawing area with picture, ignoring the picture's"
-                             " aspect ratio")
-    parser.add_argument('-f', '--force-overwrite', action='store_true',
-                        help='save to output filename even if file exists')
-    parser.add_argument('-F', '--fail', choices=('skipped', 'no-output', 'no'),
-                        default='no-output', metavar='MODE',
-                        help='If set to `skipped`, fail (exit with code 2) if at least '
-                             'one file was skipped due to an error. '
-                             'If set to `no-output` (default), fail if all files were '
-                             'skipped and no PDF file was created; succeed (exit with '
-                             'code 0) if at least one file was successfully saved. '
-                             'If set to `no`, succeed even if all files were '
-                             'skipped.')
-    parser.add_argument('-L', '--landscape', action='store_true',
-                        help='set landscape orientation of page; default is portrait')
-    parser.add_argument('-l', '--layout', default='1x1',
-                        help='specify grid layout (columns x rows) of pictures on page,'
-                             ' e.g. 2x3 or 2,3; default is 1x1')
-    parser.add_argument('-m', '--margin', type=float, default=72,
-                        help='set width of empty space around drawing areas;'
-                             ' default is 72 (72 points = 1 inch)')
-    parser.add_argument('-o', '--output-file', required=True, metavar='PATH',
-                        help='path of the output PDF file (required)')
-    parser.add_argument('-p', '--page-size', choices=PAGE_SIZES, default='A4',
-                        metavar='SIZE',
-                        help=f'specify page size; default is A4'
-                             f' (available sizes: {", ".join(PAGE_SIZES)})')
+    parser.add_argument(
+        'pictures',
+        nargs='+',
+        metavar='PICTURE',
+        help='one or more picture paths or URLs',
+    )
+    parser.add_argument(
+        '-a',
+        '--fill-area',
+        action='store_true',
+        help="fill drawing area with picture, ignoring the picture's aspect ratio",
+    )
+    parser.add_argument(
+        '-f',
+        '--force-overwrite',
+        action='store_true',
+        help='save to output filename even if file exists',
+    )
+    parser.add_argument(
+        '-F',
+        '--fail',
+        choices=('skipped', 'no-output', 'no'),
+        default='no-output',
+        metavar='MODE',
+        help='If set to `skipped`, fail (exit with code 2) if at least one file '
+             'was skipped due to an error. '
+             'If set to `no-output` (default), fail if all files were skipped '
+             'and no PDF file was created; succeed (exit with code 0) if at '
+             'least one file was successfully saved. '
+             'If set to `no`, succeed even if all files were skipped.',
+    )
+    parser.add_argument(
+        '-L',
+        '--landscape',
+        action='store_true',
+        help='set landscape orientation of page; default is portrait',
+    )
+    parser.add_argument(
+        '-l',
+        '--layout',
+        default='1x1',
+        help='specify grid layout (columns x rows) of pictures on page, '
+             'e.g. 2x3 or 2,3; default is 1x1',
+    )
+    parser.add_argument(
+        '-m',
+        '--margin',
+        type=float,
+        default=72,
+        help='set width of empty space around drawing areas; '
+             'default is 72 (72 points = 1 inch)',
+    )
+    parser.add_argument(
+        '-o',
+        '--output-file',
+        required=True,
+        metavar='PATH',
+        help='path of the output PDF file (required)',
+    )
+    parser.add_argument(
+        '-p',
+        '--page-size',
+        choices=PAGE_SIZES,
+        default='A4',
+        metavar='SIZE',
+        help='specify page size; default is A4 '
+             f'(available sizes: {", ".join(PAGE_SIZES)})',
+    )
     verbosity_group = parser.add_mutually_exclusive_group()
-    verbosity_group.add_argument('-q', '--quiet', action='store_true',
-                                 help='suppress printing to stdout')
-    parser.add_argument('-s', '--stretch-small', action='store_true',
-                        help='scale small pictures up to fit drawing areas')
-    verbosity_group.add_argument('-v', '--verbose', action='store_true',
-                                 help='show details on files skipped due to error')
+    verbosity_group.add_argument(
+        '-q',
+        '--quiet',
+        action='store_true',
+        help='suppress printing to stdout',
+    )
+    parser.add_argument(
+        '-s',
+        '--stretch-small',
+        action='store_true',
+        help='scale small pictures up to fit drawing areas',
+    )
+    verbosity_group.add_argument(
+        '-v',
+        '--verbose',
+        action='store_true',
+        help='show details on files skipped due to error',
+    )
     parser.add_argument('-V', '--version', action='version')
 
     return parser.parse_args()
@@ -105,14 +155,14 @@ def main():
         try:
             pic_show = PictureShow(*args.pictures)
             for ok_flag in pic_show._save_pdf(
-                output_file=output_file,
-                page_size=args.page_size,
-                landscape=args.landscape,
-                margin=args.margin,
-                layout=args.layout,
-                stretch_small=args.stretch_small,
-                fill_area=args.fill_area,
-                force_overwrite=args.force_overwrite
+                    output_file=output_file,
+                    page_size=args.page_size,
+                    landscape=args.landscape,
+                    margin=args.margin,
+                    layout=args.layout,
+                    stretch_small=args.stretch_small,
+                    fill_area=args.fill_area,
+                    force_overwrite=args.force_overwrite,
             ):
                 print('.' if ok_flag else '!', end='', flush=True)
             print()

--- a/src/pictureshow/core.py
+++ b/src/pictureshow/core.py
@@ -46,8 +46,14 @@ class PictureShow:
         `num_pages` - number of pages of the resulting PDF document
         """
         for _ in self._save_pdf(
-            output_file, page_size, landscape, margin, layout, stretch_small,
-            fill_area, force_overwrite
+                output_file,
+                page_size,
+                landscape,
+                margin,
+                layout,
+                stretch_small,
+                fill_area,
+                force_overwrite,
         ):
             pass
         return self.result
@@ -88,7 +94,7 @@ class PictureShow:
                     self._backend.get_picture_size(picture),
                     area[2:],    # short for (area.width, area.height)
                     stretch_small,
-                    fill_area
+                    fill_area,
                 )
                 self._backend.add_picture(
                     picture, area.x + x, area.y + y, pic_width, pic_height
@@ -228,6 +234,12 @@ def pictures_to_pdf(
     pic_show = PictureShow(*pic_files)
 
     return pic_show.save_pdf(
-        output_file, page_size, landscape, margin, layout, stretch_small, fill_area,
-        force_overwrite
+        output_file,
+        page_size,
+        landscape,
+        margin,
+        layout,
+        stretch_small,
+        fill_area,
+        force_overwrite,
     )

--- a/src/pictureshow/core.py
+++ b/src/pictureshow/core.py
@@ -27,9 +27,17 @@ class PictureShow:
         self._pic_files = pic_files
         self._backend = ReportlabBackend()
 
-    def save_pdf(self, output_file, page_size='A4', landscape=False, margin=72,
-                 layout=(1, 1), stretch_small=False, fill_area=False,
-                 force_overwrite=False):
+    def save_pdf(
+            self,
+            output_file,
+            page_size='A4',
+            landscape=False,
+            margin=72,
+            layout=(1, 1),
+            stretch_small=False,
+            fill_area=False,
+            force_overwrite=False,
+    ):
         """Save pictures stored in `self._pic_files` to a PDF document.
 
         Return a named tuple of three values:
@@ -44,8 +52,17 @@ class PictureShow:
             pass
         return self.result
 
-    def _save_pdf(self, output_file, page_size, landscape, margin, layout,
-                  stretch_small, fill_area, force_overwrite):
+    def _save_pdf(
+            self,
+            output_file,
+            page_size,
+            landscape,
+            margin,
+            layout,
+            stretch_small,
+            fill_area,
+            force_overwrite,
+    ):
         output_file = self._validate_target_path(output_file, force_overwrite)
         page_size = self._validate_page_size(page_size, landscape)
         layout = self._validate_layout(layout)
@@ -190,9 +207,17 @@ class PictureShow:
             yield DrawingArea(x, y, area_width, area_height)
 
 
-def pictures_to_pdf(*pic_files, output_file, page_size='A4', landscape=False,
-                    margin=72, layout=(1, 1), stretch_small=False, fill_area=False,
-                    force_overwrite=False):
+def pictures_to_pdf(
+        *pic_files,
+        output_file,
+        page_size='A4',
+        landscape=False,
+        margin=72,
+        layout=(1, 1),
+        stretch_small=False,
+        fill_area=False,
+        force_overwrite=False,
+):
     """Save one or more pictures to a PDF document.
 
     Return a named tuple of three values:

--- a/src/pictureshow/core.py
+++ b/src/pictureshow/core.py
@@ -30,6 +30,7 @@ class PictureShow:
     def save_pdf(
             self,
             output_file,
+            *,
             page_size='A4',
             landscape=False,
             margin=72,
@@ -47,13 +48,13 @@ class PictureShow:
         """
         for _ in self._save_pdf(
                 output_file,
-                page_size,
-                landscape,
-                margin,
-                layout,
-                stretch_small,
-                fill_area,
-                force_overwrite,
+                page_size=page_size,
+                landscape=landscape,
+                margin=margin,
+                layout=layout,
+                stretch_small=stretch_small,
+                fill_area=fill_area,
+                force_overwrite=force_overwrite,
         ):
             pass
         return self.result
@@ -61,6 +62,7 @@ class PictureShow:
     def _save_pdf(
             self,
             output_file,
+            *,
             page_size,
             landscape,
             margin,
@@ -235,11 +237,11 @@ def pictures_to_pdf(
 
     return pic_show.save_pdf(
         output_file,
-        page_size,
-        landscape,
-        margin,
-        layout,
-        stretch_small,
-        fill_area,
-        force_overwrite,
+        page_size=page_size,
+        landscape=landscape,
+        margin=margin,
+        layout=layout,
+        stretch_small=stretch_small,
+        fill_area=fill_area,
+        force_overwrite=force_overwrite,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,11 +25,11 @@ PICS_MISSING = ('missing.png',)
 @pytest.mark.parametrize(
     'number, noun, expected',
     (
-            pytest.param(1, 'file', '1 file', id='1 file'),
-            pytest.param(2, 'file', '2 files', id='2 files'),
-            pytest.param(1, 'picture', '1 picture', id='1 picture'),
-            pytest.param(3, 'page', '3 pages', id='3 pages'),
-    )
+        pytest.param(1, 'file', '1 file', id='1 file'),
+        pytest.param(2, 'file', '2 files', id='2 files'),
+        pytest.param(1, 'picture', '1 picture', id='1 picture'),
+        pytest.param(3, 'page', '3 pages', id='3 pages'),
+    ),
 )
 def test_number(number, noun, expected):
     assert _number(number, noun) == expected
@@ -38,10 +38,10 @@ def test_number(number, noun, expected):
 @pytest.mark.parametrize(
     'path, expected',
     (
-            pytest.param('pics', 'pics.pdf', id='no suffix'),
-            pytest.param('pics.pdf', 'pics.pdf', id='.pdf suffix'),
-            pytest.param('pics.pics', 'pics.pics', id='other suffix'),
-    )
+        pytest.param('pics', 'pics.pdf', id='no suffix'),
+        pytest.param('pics.pdf', 'pics.pdf', id='.pdf suffix'),
+        pytest.param('pics.pics', 'pics.pics', id='other suffix'),
+    ),
 )
 def test_ensure_suffix(path, expected):
     assert _ensure_suffix(path) == expected
@@ -59,7 +59,7 @@ class TestCommandLine:
         (
             pytest.param(PICS_1_GOOD, 1, '.', '1 picture', '1 page', id='1 valid'),
             pytest.param(PICS_2_GOOD, 2, '..', '2 pictures', '2 pages', id='2 valid'),
-        )
+        ),
     )
     def test_valid_input(self, new_pdf, pic_files, num_pages, progress, pics, pages):
         pic_files = ' '.join(str(path) for path in pic_files)
@@ -94,7 +94,7 @@ class TestCommandLine:
             pytest.param(PICS_2_BAD, '!!', '2 files', id='2 invalid'),
             pytest.param(PICS_DIR, '!', '1 file', id='dir'),
             pytest.param(PICS_MISSING, '!', '1 file', id='missing'),
-        )
+        ),
     )
     def test_invalid_input(self, new_pdf, pic_files, progress, num_invalid):
         pic_files = ' '.join(str(path) for path in pic_files)
@@ -125,7 +125,7 @@ class TestCommandLine:
             pytest.param('1x3', 2, '2 pages', id='1x3'),
             pytest.param('3,2', 1, '1 page', id='3,2'),
             pytest.param('1,1', 6, '6 pages', id='1,1'),
-        )
+        ),
     )
     def test_multiple_pictures_layout(self, new_pdf, layout, num_pages, pages):
         # 6 pictures
@@ -144,7 +144,7 @@ class TestCommandLine:
         (
             pytest.param('1', id='invalid format'),
             pytest.param('0x1', id='invalid value'),
-        )
+        ),
     )
     def test_invalid_layout_throws_error(self, new_pdf, layout):
         command = f'pictureshow -l{layout} {PIC_FILE} -o {new_pdf}'
@@ -279,7 +279,7 @@ class TestFailOnSkippedFiles:
             pytest.param(PICS_1_GOOD, 0, id='no skipped'),
             pytest.param(PICS_1_GOOD_1_BAD, 2, id='some skipped'),
             pytest.param(PICS_1_BAD, 2, id='all skipped'),
-        )
+        ),
     )
     def test_skipped(self, new_pdf, pic_files, expected_code):
         pic_files = ' '.join(str(path) for path in pic_files)
@@ -294,7 +294,7 @@ class TestFailOnSkippedFiles:
             pytest.param(PICS_1_GOOD, 0, id='no skipped'),
             pytest.param(PICS_1_GOOD_1_BAD, 0, id='some skipped'),
             pytest.param(PICS_1_BAD, 2, id='all skipped'),
-        )
+        ),
     )
     def test_no_output(self, new_pdf, pic_files, expected_code):
         pic_files = ' '.join(str(path) for path in pic_files)
@@ -309,7 +309,7 @@ class TestFailOnSkippedFiles:
             pytest.param(PICS_1_GOOD, 0, id='no skipped'),
             pytest.param(PICS_1_GOOD_1_BAD, 0, id='some skipped'),
             pytest.param(PICS_1_BAD, 0, id='all skipped'),
-        )
+        ),
     )
     def test_no(self, new_pdf, pic_files, expected_code):
         pic_files = ' '.join(str(path) for path in pic_files)

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -39,8 +39,13 @@ class TestSavePdf:
                          id='1 valid + 1 invalid'),
         )
     )
-    def test_valid_input(self, mocker, reader_side_effects, expected_ok,
-                         expected_errors):
+    def test_valid_input(
+            self,
+            mocker,
+            reader_side_effects,
+            expected_ok,
+            expected_errors,
+    ):
         pic_files = ['foo.png'] * len(reader_side_effects)
         output_file = 'foo.pdf'
         mocker.patch('pictureshow.backends.ImageReader', autospec=True,
@@ -87,8 +92,13 @@ class TestSavePdf:
             pytest.param([picture(), picture(), picture()], 3, 2, id='3 valid'),
         )
     )
-    def test_multipage_layout(self, mocker, reader_side_effects, expected_ok,
-                              expected_pages):
+    def test_multipage_layout(
+            self,
+            mocker,
+            reader_side_effects,
+            expected_ok,
+            expected_pages,
+    ):
         pic_files = ['foo.png'] * len(reader_side_effects)
         output_file = 'foo.pdf'
         mocker.patch('pictureshow.backends.ImageReader', autospec=True,
@@ -345,8 +355,7 @@ class TestValidPictures:
                          id='2 invalid + 1 valid'),
         )
     )
-    def test_valid_and_invalid_pictures(self, mocker, reader_side_effects,
-                                        expected):
+    def test_valid_and_invalid_pictures(self, mocker, reader_side_effects, expected):
         pic_files = ['foo.png'] * len(reader_side_effects)
         pic_show = PictureShow(*pic_files)
         mocker.patch('pictureshow.backends.ImageReader', autospec=True,

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -14,8 +14,13 @@ A4 = A4_WIDTH, A4_LENGTH
 A4_LANDSCAPE = A4_LENGTH, A4_WIDTH
 
 DEFAULTS = dict(
-    page_size=A4, landscape=False, margin=72, layout=(1, 1), stretch_small=False,
-    fill_area=False, force_overwrite=False
+    page_size=A4,
+    landscape=False,
+    margin=72,
+    layout=(1, 1),
+    stretch_small=False,
+    fill_area=False,
+    force_overwrite=False,
 )
 
 
@@ -35,9 +40,8 @@ class TestSavePdf:
         (
             pytest.param([picture()], 1, 0, id='1 valid'),
             pytest.param([picture(), picture()], 2, 0, id='2 valid'),
-            pytest.param([picture(), ImageError()], 1, 1,
-                         id='1 valid + 1 invalid'),
-        )
+            pytest.param([picture(), ImageError()], 1, 1, id='1 valid + 1 invalid'),
+        ),
     )
     def test_valid_input(
             self,
@@ -48,8 +52,11 @@ class TestSavePdf:
     ):
         pic_files = ['foo.png'] * len(reader_side_effects)
         output_file = 'foo.pdf'
-        mocker.patch('pictureshow.backends.ImageReader', autospec=True,
-                     side_effect=reader_side_effects)
+        mocker.patch(
+            'pictureshow.backends.ImageReader',
+            autospec=True,
+            side_effect=reader_side_effects,
+        )
         mocker.patch('pictureshow.backends.Canvas', autospec=True)
 
         pic_show = PictureShow(*pic_files)
@@ -68,13 +75,16 @@ class TestSavePdf:
             pytest.param(
                 [IsADirectoryError(), FileNotFoundError()], 2, id='dir + missing'
             ),
-        )
+        ),
     )
     def test_invalid_input(self, mocker, reader_side_effects, expected_errors):
         pic_files = ['foo.png'] * len(reader_side_effects)
         output_file = 'foo.pdf'
-        mocker.patch('pictureshow.backends.ImageReader', autospec=True,
-                     side_effect=reader_side_effects)
+        mocker.patch(
+            'pictureshow.backends.ImageReader',
+            autospec=True,
+            side_effect=reader_side_effects,
+        )
         mocker.patch('pictureshow.backends.Canvas', autospec=True)
 
         pic_show = PictureShow(*pic_files)
@@ -90,7 +100,7 @@ class TestSavePdf:
         (
             pytest.param([picture(), picture()], 2, 1, id='2 valid'),
             pytest.param([picture(), picture(), picture()], 3, 2, id='3 valid'),
-        )
+        ),
     )
     def test_multipage_layout(
             self,
@@ -101,8 +111,11 @@ class TestSavePdf:
     ):
         pic_files = ['foo.png'] * len(reader_side_effects)
         output_file = 'foo.pdf'
-        mocker.patch('pictureshow.backends.ImageReader', autospec=True,
-                     side_effect=reader_side_effects)
+        mocker.patch(
+            'pictureshow.backends.ImageReader',
+            autospec=True,
+            side_effect=reader_side_effects,
+        )
         mocker.patch('pictureshow.backends.Canvas', autospec=True)
         params = {**DEFAULTS, 'layout': (1, 2)}
 
@@ -123,8 +136,7 @@ class TestValidateTargetPath:
         Path.return_value.exists.return_value = False
         output_file = 'foo.pdf'
 
-        result = PictureShow()._validate_target_path(output_file,
-                                                     force_overwrite=False)
+        result = PictureShow()._validate_target_path(output_file, force_overwrite=False)
         assert result == output_file
 
     def test_existing_target_file_raises_error(self, mocker):
@@ -132,16 +144,14 @@ class TestValidateTargetPath:
         Path.return_value.exists.return_value = True
 
         with pytest.raises(FileExistsError, match="file '.*' exists"):
-            PictureShow()._validate_target_path('foo.pdf',
-                                                force_overwrite=False)
+            PictureShow()._validate_target_path('foo.pdf', force_overwrite=False)
 
     def test_force_overwrite_existing_file(self, mocker):
         Path = mocker.patch('pictureshow.core.Path', autospec=True)
         Path.return_value.exists.return_value = True
         output_file = 'foo.pdf'
 
-        result = PictureShow()._validate_target_path(output_file,
-                                                     force_overwrite=True)
+        result = PictureShow()._validate_target_path(output_file, force_overwrite=True)
         assert result == output_file
 
     def test_target_pathlike_converted_to_str(self, mocker):
@@ -149,8 +159,7 @@ class TestValidateTargetPath:
         Path_mock.return_value.exists.return_value = False
         output_file = Path('foo.pdf')
 
-        result = PictureShow()._validate_target_path(output_file,
-                                                     force_overwrite=False)
+        result = PictureShow()._validate_target_path(output_file, force_overwrite=False)
         assert result == str(output_file)
 
 
@@ -162,7 +171,7 @@ class TestValidatePageSize:
         (
             pytest.param(A4, id='A4'),
             pytest.param((11.5 * 72, 8.5 * 72), id='custom'),
-        )
+        ),
     )
     def test_page_size_as_tuple(self, page_size):
         result = PictureShow()._validate_page_size(page_size, landscape=False)
@@ -173,7 +182,7 @@ class TestValidatePageSize:
         (
             pytest.param('A4', A4, id="'A4'"),
             pytest.param('letter', (72 * 8.5, 72 * 11), id="'letter'"),
-        )
+        ),
     )
     def test_page_size_as_str(self, page_size, expected):
         result = PictureShow()._validate_page_size(page_size, landscape=False)
@@ -184,7 +193,7 @@ class TestValidatePageSize:
         (
             pytest.param('A4', [210, 297], id="'A4'"),
             pytest.param('b0', [1000, 1414], id="'b0'"),
-        )
+        ),
     )
     def test_valid_names_mm(self, page_size, expected_mm):
         w, h = PictureShow()._validate_page_size(page_size, landscape=False)
@@ -195,7 +204,7 @@ class TestValidatePageSize:
         (
             pytest.param('LETTER', [8.5, 11], id="'LETTER'"),
             pytest.param('legal', [8.5, 14], id="'legal'"),
-        )
+        ),
     )
     def test_valid_names_inches(self, page_size, expected_inches):
         w, h = PictureShow()._validate_page_size(page_size, landscape=False)
@@ -207,7 +216,7 @@ class TestValidatePageSize:
             pytest.param(A4, A4_LANDSCAPE, id='A4'),
             pytest.param('A3', (420 / 25.4 * 72, 297 / 25.4 * 72), id="'A3'"),
             pytest.param((8.5*72, 10.5*72), (10.5*72, 8.5*72), id='custom'),
-        )
+        ),
     )
     def test_portrait_converted_to_landscape(self, page_size, expected):
         result = PictureShow()._validate_page_size(page_size, landscape=True)
@@ -219,7 +228,7 @@ class TestValidatePageSize:
             pytest.param(A4_LANDSCAPE, A4_LANDSCAPE, id='A4'),
             pytest.param('LEDGER', [17 * 72, 11 * 72], id="'LEDGER'"),
             pytest.param((10.5*72, 8.5*72), (10.5*72, 8.5*72), id='custom'),
-        )
+        ),
     )
     def test_landscape_remains_landscape(self, page_size, expected):
         result = PictureShow()._validate_page_size(page_size, landscape=True)
@@ -234,11 +243,10 @@ class TestValidatePageSize:
             pytest.param((500.0, -200.0), id='invalid value (negative)'),
             pytest.param((500.0, '500.0'), id='invalid type (str)'),
             pytest.param(1, id='not iterable'),
-        )
+        ),
     )
     def test_invalid_page_size_raises_error(self, page_size):
-        with pytest.raises(PageSizeError,
-                           match='two positive numbers expected'):
+        with pytest.raises(PageSizeError, match='two positive numbers expected'):
             PictureShow()._validate_page_size(page_size, landscape=False)
 
     @pytest.mark.parametrize(
@@ -246,12 +254,13 @@ class TestValidatePageSize:
         (
             pytest.param('A11', id="'A11'"),
             pytest.param('portrait', id="'portrait'"),
-        )
+        ),
     )
     def test_invalid_page_size_name_raises_error(self, page_size):
-        with pytest.raises(PageSizeError,
-                           match='unknown page size .+,'
-                                 ' please use one of: A0, A1.+'):
+        with pytest.raises(
+                PageSizeError,
+                match='unknown page size .+, please use one of: A0, A1.+',
+        ):
             PictureShow()._validate_page_size(page_size, landscape=False)
 
 
@@ -264,7 +273,7 @@ class TestValidateLayout:
             pytest.param((1, 1), id='(1, 1)'),
             pytest.param((1, 2), id='(1, 2)'),
             pytest.param((4, 2), id='(4, 2)'),
-        )
+        ),
     )
     def test_layout_as_tuple(self, layout):
         assert PictureShow()._validate_layout(layout) == layout
@@ -275,7 +284,7 @@ class TestValidateLayout:
             pytest.param([1, 2], (1, 2), id='list'),
             pytest.param(range(2, 5)[:2], (2, 3), id='iter'),
             pytest.param(b'\x05\x03', (5, 3), id='bytes'),
-        )
+        ),
     )
     def test_layout_as_other_sequence(self, layout, expected):
         result = PictureShow()._validate_layout(layout)
@@ -290,7 +299,7 @@ class TestValidateLayout:
             pytest.param('1,1', (1, 1), id='1,1'),
             pytest.param('03,01', (3, 1), id='03,01'),
             pytest.param(' 2 , 3 ', (2, 3), id=' 2 , 3 '),
-        )
+        ),
     )
     def test_layout_as_str(self, layout, expected):
         result = PictureShow()._validate_layout(layout)
@@ -306,7 +315,7 @@ class TestValidateLayout:
             pytest.param((1, 0.5), id='invalid type (float)'),
             pytest.param(('1', '1'), id='invalid type (str)'),
             pytest.param(0, id='not iterable'),
-        )
+        ),
     )
     def test_invalid_layout_raises_error(self, layout):
         with pytest.raises(LayoutError, match='two positive integers expected'):
@@ -320,7 +329,7 @@ class TestValidateLayout:
             pytest.param('0x1', id='invalid value (zero)'),
             pytest.param('-1x3', id='invalid value (negative)'),
             pytest.param('1x0.5', id='invalid type (float)'),
-        )
+        ),
     )
     def test_invalid_layout_str_raises_error(self, layout):
         with pytest.raises(LayoutError, match='two positive integers expected'):
@@ -335,13 +344,16 @@ class TestValidPictures:
         (
             pytest.param([picture()], id='1 valid'),
             pytest.param([picture(), picture()], id='2 valid'),
-        )
+        ),
     )
     def test_all_valid_pictures(self, mocker, reader_side_effects):
         pic_files = ['foo.png'] * len(reader_side_effects)
         pic_show = PictureShow(*pic_files)
-        mocker.patch('pictureshow.backends.ImageReader', autospec=True,
-                     side_effect=reader_side_effects)
+        mocker.patch(
+            'pictureshow.backends.ImageReader',
+            autospec=True,
+            side_effect=reader_side_effects,
+        )
         result = list(pic_show._valid_pictures())
 
         assert result == reader_side_effects
@@ -351,15 +363,21 @@ class TestValidPictures:
         'reader_side_effects, expected',
         (
             pytest.param([1, ImageError(), 2], [1, None, 2], id='2 valid + 1 invalid'),
-            pytest.param([ImageError(), 1, ImageError()], [None, 1, None],
-                         id='2 invalid + 1 valid'),
-        )
+            pytest.param(
+                [ImageError(), 1, ImageError()],
+                [None, 1, None],
+                id='2 invalid + 1 valid',
+            ),
+        ),
     )
     def test_valid_and_invalid_pictures(self, mocker, reader_side_effects, expected):
         pic_files = ['foo.png'] * len(reader_side_effects)
         pic_show = PictureShow(*pic_files)
-        mocker.patch('pictureshow.backends.ImageReader', autospec=True,
-                     side_effect=reader_side_effects)
+        mocker.patch(
+            'pictureshow.backends.ImageReader',
+            autospec=True,
+            side_effect=reader_side_effects,
+        )
         result = list(pic_show._valid_pictures())
 
         assert result == expected
@@ -375,13 +393,16 @@ class TestValidPictures:
                 [None, None],
                 id='dir + missing',
             ),
-        )
+        ),
     )
     def test_all_invalid_pictures(self, mocker, reader_side_effects, expected):
         pic_files = ['foo.png'] * len(reader_side_effects)
         pic_show = PictureShow(*pic_files)
-        mocker.patch('pictureshow.backends.ImageReader', autospec=True,
-                     side_effect=reader_side_effects)
+        mocker.patch(
+            'pictureshow.backends.ImageReader',
+            autospec=True,
+            side_effect=reader_side_effects,
+        )
         result = list(pic_show._valid_pictures())
 
         assert result == expected
@@ -400,12 +421,12 @@ class TestPositionAndSize:
         (
             pytest.param((800, 387), A4_PORTRAIT_MARGIN_72, id='portrait'),
             pytest.param((800, 387), A4_LANDSCAPE_MARGIN_72, id='landscape'),
-        )
+        ),
     )
     def test_big_wide_picture_fills_area_x(self, pic_size, area_size):
         original_aspect = pic_size[0] / pic_size[1]
         x, y, new_width, new_height = PictureShow()._position_and_size(
-            pic_size, area_size, False, False
+            pic_size, area_size, stretch_small=False, fill_area=False
         )
         assert x == 0
         assert new_width == area_size[0]
@@ -416,12 +437,12 @@ class TestPositionAndSize:
         (
             pytest.param((400, 3260), A4_PORTRAIT_MARGIN_72, id='portrait'),
             pytest.param((400, 3260), A4_LANDSCAPE_MARGIN_72, id='landscape'),
-        )
+        ),
     )
     def test_big_tall_picture_fills_area_y(self, pic_size, area_size):
         original_aspect = pic_size[0] / pic_size[1]
         x, y, new_width, new_height = PictureShow()._position_and_size(
-            pic_size, area_size, False, False
+            pic_size, area_size, stretch_small=False, fill_area=False
         )
         assert y == 0
         assert new_height == area_size[1]
@@ -430,7 +451,7 @@ class TestPositionAndSize:
     def test_small_picture_not_resized(self):
         pic_size = (320, 200)
         x, y, new_width, new_height = PictureShow()._position_and_size(
-            pic_size, A4_PORTRAIT_MARGIN_72, False, False
+            pic_size, A4_PORTRAIT_MARGIN_72, stretch_small=False, fill_area=False
         )
         assert (new_width, new_height) == pic_size
 
@@ -439,7 +460,7 @@ class TestPositionAndSize:
         (
             pytest.param((192, 108), A4_PORTRAIT_MARGIN_72, id='portrait'),
             pytest.param((192, 108), A4_LANDSCAPE_MARGIN_72, id='landscape'),
-        )
+        ),
     )
     def test_small_wide_picture_stretch_small(self, pic_size, area_size):
         original_aspect = pic_size[0] / pic_size[1]
@@ -455,7 +476,7 @@ class TestPositionAndSize:
         (
             pytest.param((68, 112), A4_PORTRAIT_MARGIN_72, id='portrait'),
             pytest.param((68, 112), A4_LANDSCAPE_MARGIN_72, id='landscape'),
-        )
+        ),
     )
     def test_small_tall_picture_stretch_small(self, pic_size, area_size):
         original_aspect = pic_size[0] / pic_size[1]
@@ -472,7 +493,7 @@ class TestPositionAndSize:
             pytest.param((800, 387), A4_PORTRAIT_MARGIN_72, id='big wide picture'),
             pytest.param((400, 3260), A4_PORTRAIT_MARGIN_72, id='big tall picture'),
             pytest.param((320, 200), A4_PORTRAIT_MARGIN_72, id='small picture'),
-        )
+        ),
     )
     def test_fill_area(self, pic_size, area_size):
         x, y, new_width, new_height = PictureShow()._position_and_size(
@@ -493,7 +514,7 @@ class TestAreas:
             pytest.param((1, 1), id='1x1'),
             pytest.param((1, 2), id='1x2'),
             pytest.param((1, 5), id='1x5'),
-        )
+        ),
     )
     def test_single_column_layout(self, layout):
         page_size, margin = A4, 72
@@ -514,7 +535,7 @@ class TestAreas:
             pytest.param((1, 1), id='1x1'),
             pytest.param((2, 1), id='2x1'),
             pytest.param((5, 1), id='5x1'),
-        )
+        ),
     )
     def test_single_row_layout(self, layout):
         page_size, margin = A4, 72
@@ -535,7 +556,7 @@ class TestAreas:
             pytest.param((3, 3), A4, 18, id='(3, 3) portrait'),
             pytest.param((3, 3), A4, 0, id='(3, 3) portrait no margin'),
             pytest.param((3, 3), A4_LANDSCAPE, 36, id='(3, 3) landscape'),
-        )
+        ),
     )
     def test_3x3_layout(self, layout, page_size, margin):
         areas = list(PictureShow()._areas(layout, page_size, margin))
@@ -556,7 +577,7 @@ class TestAreas:
             pytest.param((1, 1), A4_WIDTH/2, id='A4 width/2'),
             pytest.param((1, 2), 300, id='300'),
             pytest.param((1, 2), A4_LENGTH/3, id='A4 length/3'),
-        )
+        ),
     )
     def test_high_margin_raises_error(self, layout, margin):
         with pytest.raises(MarginError, match='margin value too high: .+'):


### PR DESCRIPTION
Change the following parameters of `PictureShow._save_pdf` and ``PictureShow.save_pdf`` to keyword-only:

- `force_overwrite`
- `page_size`
- `landscape`
- `layout`
- `margin`
- `stretch_small`
- `fill_area`

Reformat multi-line function signatures and calls.
