### PR TITLE
Rename drawing areas to cells

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,11 +56,11 @@ As a command line tool
     picture layout options:
       -l, --layout LAYOUT   specify grid layout (columns x rows) of pictures on
                             page, e.g. 2x3 or 2,3; default is 1x1
-      -m, --margin MARGIN   set width of empty space around drawing areas; default
-                            is 72 (72 points = 1 inch)
-      -s, --stretch-small   scale small pictures up to fit drawing areas
-      -a, --fill-area       fill drawing areas with pictures, ignoring the
-                            pictures' aspect ratio
+      -m, --margin MARGIN   set width of empty space around the cells containing
+                            pictures; default is 72 (72 points = 1 inch)
+      -s, --stretch-small   scale small pictures up to fit cells
+      -c, --fill-cell       fill cells with pictures, ignoring the pictures'
+                            aspect ratio
 
 
 Examples
@@ -132,7 +132,7 @@ and their default values correspond to the above shown command line options:
         layout=(1, 1),
         margin=72,
         stretch_small=False,
-        fill_area=False,
+        fill_cell=False,
     )
 
 
@@ -166,7 +166,7 @@ their default values correspond to the above shown command line options:
         layout=(1, 1),
         margin=72,
         stretch_small=False,
-        fill_area=False,
+        fill_cell=False,
     )
 
 

--- a/changelog.d/20241015_095444_michalportes1_cell_box.md
+++ b/changelog.d/20241015_095444_michalportes1_cell_box.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Breaking changes
+
+- Library API: `fill_area` keyword parameters renamed to `fill_cell`
+- CLI: the `-a`/`--fill-area` option renamed to `-c`/`--fill-cell`
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/pictureshow/cli.py
+++ b/src/pictureshow/cli.py
@@ -117,20 +117,20 @@ def _setup_parser():
         '--margin',
         type=float,
         default=72,
-        help='set width of empty space around drawing areas; '
+        help='set width of empty space around the cells containing pictures; '
              'default is %(default)s (72 points = 1 inch)',
     )
     picture_group.add_argument(
         '-s',
         '--stretch-small',
         action='store_true',
-        help='scale small pictures up to fit drawing areas',
+        help='scale small pictures up to fit cells',
     )
     picture_group.add_argument(
-        '-a',
-        '--fill-area',
+        '-c',
+        '--fill-cell',
         action='store_true',
-        help="fill drawing areas with pictures, ignoring the pictures' aspect ratio",
+        help="fill cells with pictures, ignoring the pictures' aspect ratio",
     )
 
     return parser
@@ -193,7 +193,7 @@ def main(argv=None):
                     layout=args.layout,
                     margin=args.margin,
                     stretch_small=args.stretch_small,
-                    fill_area=args.fill_area,
+                    fill_cell=args.fill_cell,
             ):
                 print('.' if ok_flag else '!', end='', flush=True)
             print()

--- a/tests/test_pictures_to_pdf.py
+++ b/tests/test_pictures_to_pdf.py
@@ -173,8 +173,8 @@ def test_stretch_small(new_pdf):
     assert_pdf(new_pdf, 1)
 
 
-def test_fill_area(new_pdf):
-    result = pictures_to_pdf(PIC_FILE, output_file=new_pdf, fill_area=True)
+def test_fill_cell(new_pdf):
+    result = pictures_to_pdf(PIC_FILE, output_file=new_pdf, fill_cell=True)
 
     assert result == (1, [], 1)
     assert_pdf(new_pdf, 1)

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -23,7 +23,7 @@ DEFAULTS = dict(
     layout=(1, 1),
     margin=72,
     stretch_small=False,
-    fill_area=False,
+    fill_cell=False,
 )
 
 
@@ -399,96 +399,96 @@ class TestPositionAndSize:
     """Test core.PictureShow._position_and_size"""
 
     @pytest.mark.parametrize(
-        'pic_size, area_size',
+        'pic_size, cell_size',
         (
             pytest.param((800, 387), A4_PORTRAIT_MARGIN_72, id='portrait'),
             pytest.param((800, 387), A4_LANDSCAPE_MARGIN_72, id='landscape'),
         ),
     )
-    def test_big_wide_picture_fills_area_x(self, pic_size, area_size):
+    def test_big_wide_picture_fills_cell_x(self, pic_size, cell_size):
         original_aspect = pic_size[0] / pic_size[1]
         x, y, new_width, new_height = PictureShow()._position_and_size(
-            pic_size, area_size, stretch_small=False, fill_area=False
+            pic_size, cell_size, stretch_small=False, fill_cell=False
         )
         assert x == 0
-        assert new_width == area_size[0]
+        assert new_width == cell_size[0]
         assert new_width / new_height == pytest.approx(original_aspect)
 
     @pytest.mark.parametrize(
-        'pic_size, area_size',
+        'pic_size, cell_size',
         (
             pytest.param((400, 3260), A4_PORTRAIT_MARGIN_72, id='portrait'),
             pytest.param((400, 3260), A4_LANDSCAPE_MARGIN_72, id='landscape'),
         ),
     )
-    def test_big_tall_picture_fills_area_y(self, pic_size, area_size):
+    def test_big_tall_picture_fills_cell_y(self, pic_size, cell_size):
         original_aspect = pic_size[0] / pic_size[1]
         x, y, new_width, new_height = PictureShow()._position_and_size(
-            pic_size, area_size, stretch_small=False, fill_area=False
+            pic_size, cell_size, stretch_small=False, fill_cell=False
         )
         assert y == 0
-        assert new_height == area_size[1]
+        assert new_height == cell_size[1]
         assert new_width / new_height == pytest.approx(original_aspect)
 
     def test_small_picture_not_resized(self):
         pic_size = (320, 200)
         x, y, new_width, new_height = PictureShow()._position_and_size(
-            pic_size, A4_PORTRAIT_MARGIN_72, stretch_small=False, fill_area=False
+            pic_size, A4_PORTRAIT_MARGIN_72, stretch_small=False, fill_cell=False
         )
         assert (new_width, new_height) == pic_size
 
     @pytest.mark.parametrize(
-        'pic_size, area_size',
+        'pic_size, cell_size',
         (
             pytest.param((192, 108), A4_PORTRAIT_MARGIN_72, id='portrait'),
             pytest.param((192, 108), A4_LANDSCAPE_MARGIN_72, id='landscape'),
         ),
     )
-    def test_small_wide_picture_stretch_small(self, pic_size, area_size):
+    def test_small_wide_picture_stretch_small(self, pic_size, cell_size):
         original_aspect = pic_size[0] / pic_size[1]
         x, y, new_width, new_height = PictureShow()._position_and_size(
-            pic_size, area_size, stretch_small=True, fill_area=False
+            pic_size, cell_size, stretch_small=True, fill_cell=False
         )
         assert x == 0
-        assert new_width == area_size[0]
+        assert new_width == cell_size[0]
         assert new_width / new_height == pytest.approx(original_aspect)
 
     @pytest.mark.parametrize(
-        'pic_size, area_size',
+        'pic_size, cell_size',
         (
             pytest.param((68, 112), A4_PORTRAIT_MARGIN_72, id='portrait'),
             pytest.param((68, 112), A4_LANDSCAPE_MARGIN_72, id='landscape'),
         ),
     )
-    def test_small_tall_picture_stretch_small(self, pic_size, area_size):
+    def test_small_tall_picture_stretch_small(self, pic_size, cell_size):
         original_aspect = pic_size[0] / pic_size[1]
         x, y, new_width, new_height = PictureShow()._position_and_size(
-            pic_size, area_size, stretch_small=True, fill_area=False
+            pic_size, cell_size, stretch_small=True, fill_cell=False
         )
         assert y == 0
-        assert new_height == area_size[1]
+        assert new_height == cell_size[1]
         assert new_width / new_height == pytest.approx(original_aspect)
 
     @pytest.mark.parametrize(
-        'pic_size, area_size',
+        'pic_size, cell_size',
         (
             pytest.param((800, 387), A4_PORTRAIT_MARGIN_72, id='big wide picture'),
             pytest.param((400, 3260), A4_PORTRAIT_MARGIN_72, id='big tall picture'),
             pytest.param((320, 200), A4_PORTRAIT_MARGIN_72, id='small picture'),
         ),
     )
-    def test_fill_area(self, pic_size, area_size):
+    def test_fill_cell(self, pic_size, cell_size):
         x, y, new_width, new_height = PictureShow()._position_and_size(
-            pic_size, area_size, stretch_small=False, fill_area=True
+            pic_size, cell_size, stretch_small=False, fill_cell=True
         )
         assert x == 0
         assert y == 0
-        assert new_width == area_size[0]
-        assert new_height == area_size[1]
+        assert new_width == cell_size[0]
+        assert new_height == cell_size[1]
 
 
-class TestAreas:
-    """Test core.PictureShow._areas"""
+class TestCells:
+    """Test core.PictureShow._cells"""
 
     @pytest.mark.parametrize(
         'layout',
@@ -500,16 +500,16 @@ class TestAreas:
     )
     def test_single_column_layout(self, layout):
         page_size, margin = A4, 72
-        areas = list(PictureShow()._areas(layout, page_size, margin))
+        cells = list(PictureShow()._cells(layout, page_size, margin))
 
-        # number of areas == number of rows
-        assert len(areas) == layout[1]
-        assert areas[-1].y == margin
+        # number of cells == number of rows
+        assert len(cells) == layout[1]
+        assert cells[-1].y == margin
 
         expected_width = A4_WIDTH - 2*margin
-        for area in areas:
-            assert area.x == margin
-            assert area.width == expected_width
+        for cell in cells:
+            assert cell.x == margin
+            assert cell.width == expected_width
 
     @pytest.mark.parametrize(
         'layout',
@@ -521,16 +521,16 @@ class TestAreas:
     )
     def test_single_row_layout(self, layout):
         page_size, margin = A4, 72
-        areas = list(PictureShow()._areas(layout, page_size, margin))
+        cells = list(PictureShow()._cells(layout, page_size, margin))
 
-        # number of areas == number of columns
-        assert len(areas) == layout[0]
-        assert areas[0].x == margin
+        # number of cells == number of columns
+        assert len(cells) == layout[0]
+        assert cells[0].x == margin
 
         expected_height = A4_LENGTH - 2*margin
-        for area in areas:
-            assert area.y == margin
-            assert area.height == expected_height
+        for cell in cells:
+            assert cell.y == margin
+            assert cell.height == expected_height
 
     @pytest.mark.parametrize(
         'layout, page_size, margin',
@@ -541,16 +541,16 @@ class TestAreas:
         ),
     )
     def test_3x3_layout(self, layout, page_size, margin):
-        areas = list(PictureShow()._areas(layout, page_size, margin))
-        assert len(areas) == 9
+        cells = list(PictureShow()._cells(layout, page_size, margin))
+        assert len(cells) == 9
 
-        # areas in the left column
-        for area in areas[::3]:
-            assert area.x == margin
+        # cells in the left column
+        for cell in cells[::3]:
+            assert cell.x == margin
 
-        # areas in the bottom row
-        for area in areas[6:]:
-            assert area.y == margin
+        # cells in the bottom row
+        for cell in cells[6:]:
+            assert cell.y == margin
 
     @pytest.mark.parametrize(
         'layout, margin',
@@ -563,4 +563,4 @@ class TestAreas:
     )
     def test_high_margin_raises_error(self, layout, margin):
         with pytest.raises(MarginError, match='margin value too high: .+'):
-            list(PictureShow()._areas(layout, A4, margin))
+            list(PictureShow()._cells(layout, A4, margin))


### PR DESCRIPTION
- core: rename `fill_area` keywords to `fill_cell`
- core: rename `_Area` to `_Box`
- CLI: rename the `-a`/`--fill-area` option to `-c`/`--fill-cell`