### PR TITLE
Refactor PDF saving and picture positioning methods

### DIFF
--- a/src/pictureshow/cli.py
+++ b/src/pictureshow/cli.py
@@ -184,7 +184,7 @@ def main(argv=None):
     with stdout_context:
         try:
             pic_show = PictureShow(*args.pictures)
-            for ok_flag in pic_show._save_pdf(
+            for ok_flag in pic_show._iter_save(
                     output_file=output_file,
                     force_overwrite=args.force_overwrite,
                     page_size=args.page_size,

--- a/src/pictureshow/core.py
+++ b/src/pictureshow/core.py
@@ -227,17 +227,21 @@ class PictureShow:
         num_columns, num_rows = layout
         page_width, page_height = page_size
 
-        cell_width = (page_width - (num_columns + 1) * margin) / num_columns
-        cell_height = (page_height - (num_rows + 1) * margin) / num_rows
+        step_x = (page_width - margin) / num_columns
+        step_y = (page_height - margin) / num_rows
+        cell_width = step_x - margin
+        cell_height = step_y - margin
+
         if cell_width < 1 or cell_height < 1:
             raise MarginError(f'margin value too high: {margin}')
 
         cells_y_coords = (
-            page_height - row * (cell_height + margin)
+            page_height - row * step_y
             for row in range(1, num_rows + 1)
         )
+
         cells_x_coords = (
-            margin + col * (cell_width + margin)
+            margin + col * step_x
             for col in range(num_columns)
         )
         # yield cells row-wise

--- a/src/pictureshow/core.py
+++ b/src/pictureshow/core.py
@@ -114,15 +114,11 @@ class PictureShow:
                     return
                 pic_box = self._picture_box(
                     self._backend.get_picture_size(picture),
-                    cell.size,
+                    cell,
                     stretch_small,
                     fill_cell,
                 )
-                self._backend.add_picture(
-                    picture,
-                    position=(cell.x + pic_box.x, cell.y + pic_box.y),
-                    size=pic_box.size,
-                )
+                self._backend.add_picture(picture, pic_box.position, pic_box.size)
                 self.num_ok += 1
                 yield True
             self._backend.add_page()
@@ -201,12 +197,12 @@ class PictureShow:
                 yield picture
 
     @staticmethod
-    def _picture_box(pic_size, cell_size, stretch_small, fill_cell):
-        """Calculate position and size of the picture within the cell."""
-        cell_width, cell_height = cell_size
+    def _picture_box(pic_size, cell, stretch_small, fill_cell):
+        """Calculate position and size of the picture on the page."""
         if fill_cell:
-            return _Box(0, 0, cell_width, cell_height)
+            return cell
 
+        cell_width, cell_height = cell.size
         pic_width, pic_height = pic_size
         fits_in_cell = pic_width <= cell_width and pic_height <= cell_height
 
@@ -220,7 +216,7 @@ class PictureShow:
         x = (cell_width - pic_width) / 2
         y = (cell_height - pic_height) / 2
 
-        return _Box(x, y, pic_width, pic_height)
+        return _Box(cell.x + x, cell.y + y, pic_width, pic_height)
 
     @staticmethod
     def _cells(layout, page_size, margin):

--- a/src/pictureshow/core.py
+++ b/src/pictureshow/core.py
@@ -63,7 +63,7 @@ class PictureShow:
         `errors` - list of items skipped due to error
         `num_pages` - number of pages of the resulting PDF document
         """
-        for _ in self._save_pdf(
+        for _ in self._iter_save(
                 output_file,
                 force_overwrite=force_overwrite,
                 page_size=page_size,
@@ -77,7 +77,7 @@ class PictureShow:
             pass
         return self.result
 
-    def _save_pdf(
+    def _iter_save(
             self,
             output_file,
             *,
@@ -112,7 +112,7 @@ class PictureShow:
                         self._backend.save()
                     self.num_pages = self._backend.num_pages
                     return
-                pic_box = self._position_and_size(
+                pic_box = self._picture_box(
                     self._backend.get_picture_size(picture),
                     cell.size,
                     stretch_small,
@@ -201,7 +201,7 @@ class PictureShow:
                 yield picture
 
     @staticmethod
-    def _position_and_size(pic_size, cell_size, stretch_small, fill_cell):
+    def _picture_box(pic_size, cell_size, stretch_small, fill_cell):
         """Calculate position and size of the picture within the cell."""
         cell_width, cell_height = cell_size
         if fill_cell:

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -5,7 +5,7 @@ import pytest
 from PIL import UnidentifiedImageError as ImageError
 
 from pictureshow.backends import ImageReader
-from pictureshow.core import PictureShow
+from pictureshow.core import _Box, PictureShow
 from pictureshow.exceptions import (
     LayoutError, MarginError, PageSizeError, RGBColorError
 )
@@ -391,43 +391,43 @@ class TestValidPictures:
         assert len(pic_show.errors) == expected.count(None)
 
 
-DEFAULT_CELL = A4_WIDTH - 144, A4_LENGTH - 144
-DEFAULT_CELL_LANDSCAPE = DEFAULT_CELL[::-1]
+DEFAULT_CELL = _Box(72, 72, A4_WIDTH - 144, A4_LENGTH - 144)
+DEFAULT_CELL_LANDSCAPE = _Box(72, 72, A4_LENGTH - 144, A4_WIDTH - 144)
 
 
 class TestPictureBox:
     """Test core.PictureShow._picture_box"""
 
     @pytest.mark.parametrize(
-        'cell_size',
+        'cell',
         (
             pytest.param(DEFAULT_CELL, id='portrait'),
             pytest.param(DEFAULT_CELL_LANDSCAPE, id='landscape'),
         ),
     )
-    def test_big_wide_picture_fills_cell_x(self, cell_size):
+    def test_big_wide_picture_fills_cell_x(self, cell):
         pic_width, pic_height = 800, 387
         pic_box = PictureShow()._picture_box(
-            (pic_width, pic_height), cell_size, stretch_small=False, fill_cell=False
+            (pic_width, pic_height), cell, stretch_small=False, fill_cell=False
         )
-        assert pic_box.x == 0
-        assert pic_box.width == cell_size[0]
+        assert pic_box.x == 72
+        assert pic_box.width == cell.width
         assert pic_box.width / pic_box.height == pytest.approx(pic_width / pic_height)
 
     @pytest.mark.parametrize(
-        'cell_size',
+        'cell',
         (
             pytest.param(DEFAULT_CELL, id='portrait'),
             pytest.param(DEFAULT_CELL_LANDSCAPE, id='landscape'),
         ),
     )
-    def test_big_tall_picture_fills_cell_y(self, cell_size):
+    def test_big_tall_picture_fills_cell_y(self, cell):
         pic_width, pic_height = 400, 3260
         pic_box = PictureShow()._picture_box(
-            (pic_width, pic_height), cell_size, stretch_small=False, fill_cell=False
+            (pic_width, pic_height), cell, stretch_small=False, fill_cell=False
         )
-        assert pic_box.y == 0
-        assert pic_box.height == cell_size[1]
+        assert pic_box.y == 72
+        assert pic_box.height == cell.height
         assert pic_box.width / pic_box.height == pytest.approx(pic_width / pic_height)
 
     def test_small_picture_not_resized(self):
@@ -438,35 +438,35 @@ class TestPictureBox:
         assert pic_box.size == pic_size
 
     @pytest.mark.parametrize(
-        'cell_size',
+        'cell',
         (
             pytest.param(DEFAULT_CELL, id='portrait'),
             pytest.param(DEFAULT_CELL_LANDSCAPE, id='landscape'),
         ),
     )
-    def test_small_wide_picture_stretch_small(self, cell_size):
+    def test_small_wide_picture_stretch_small(self, cell):
         pic_width, pic_height = 192, 108
         pic_box = PictureShow()._picture_box(
-            (pic_width, pic_height), cell_size, stretch_small=True, fill_cell=False
+            (pic_width, pic_height), cell, stretch_small=True, fill_cell=False
         )
-        assert pic_box.x == 0
-        assert pic_box.width == cell_size[0]
+        assert pic_box.x == 72
+        assert pic_box.width == cell.width
         assert pic_box.width / pic_box.height == pytest.approx(pic_width / pic_height)
 
     @pytest.mark.parametrize(
-        'cell_size',
+        'cell',
         (
             pytest.param(DEFAULT_CELL, id='portrait'),
             pytest.param(DEFAULT_CELL_LANDSCAPE, id='landscape'),
         ),
     )
-    def test_small_tall_picture_stretch_small(self, cell_size):
+    def test_small_tall_picture_stretch_small(self, cell):
         pic_width, pic_height = 68, 112
         pic_box = PictureShow()._picture_box(
-            (pic_width, pic_height), cell_size, stretch_small=True, fill_cell=False
+            (pic_width, pic_height), cell, stretch_small=True, fill_cell=False
         )
-        assert pic_box.y == 0
-        assert pic_box.height == cell_size[1]
+        assert pic_box.y == 72
+        assert pic_box.height == cell.height
         assert pic_box.width / pic_box.height == pytest.approx(pic_width / pic_height)
 
     @pytest.mark.parametrize(
@@ -478,12 +478,12 @@ class TestPictureBox:
         ),
     )
     def test_fill_cell(self, pic_size):
-        cell_size = DEFAULT_CELL
+        cell = DEFAULT_CELL
         pic_box = PictureShow()._picture_box(
-            pic_size, cell_size, stretch_small=False, fill_cell=True
+            pic_size, cell, stretch_small=False, fill_cell=True
         )
-        assert pic_box.position == (0, 0)
-        assert pic_box.size == cell_size
+        assert pic_box.position == (72, 72)
+        assert pic_box.size == cell.size
 
 
 class TestCells:

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -35,8 +35,8 @@ def picture():
     return image_reader
 
 
-class TestSavePdf:
-    """Test core.PictureShow._save_pdf"""
+class TestIterSave:
+    """Test core.PictureShow._iter_save"""
 
     @pytest.mark.parametrize(
         'reader_side_effects, expected_ok, expected_errors',
@@ -63,7 +63,7 @@ class TestSavePdf:
         mocker.patch('pictureshow.backends.Canvas', autospec=True)
 
         pic_show = PictureShow(*pic_files)
-        list(pic_show._save_pdf(output_file, **DEFAULTS))  # exhaust the generator
+        list(pic_show._iter_save(output_file, **DEFAULTS))  # exhaust the generator
         result = pic_show.result
 
         assert result.num_ok == expected_ok
@@ -91,7 +91,7 @@ class TestSavePdf:
         mocker.patch('pictureshow.backends.Canvas', autospec=True)
 
         pic_show = PictureShow(*pic_files)
-        list(pic_show._save_pdf(output_file, **DEFAULTS))  # exhaust the generator
+        list(pic_show._iter_save(output_file, **DEFAULTS))  # exhaust the generator
         result = pic_show.result
 
         assert result.num_ok == 0
@@ -123,7 +123,7 @@ class TestSavePdf:
         params = {**DEFAULTS, 'layout': (1, 2)}
 
         pic_show = PictureShow(*pic_files)
-        list(pic_show._save_pdf(output_file, **params))  # exhaust the generator
+        list(pic_show._iter_save(output_file, **params))  # exhaust the generator
         result = pic_show.result
 
         assert result.num_ok == expected_ok
@@ -395,8 +395,8 @@ DEFAULT_CELL = A4_WIDTH - 144, A4_LENGTH - 144
 DEFAULT_CELL_LANDSCAPE = DEFAULT_CELL[::-1]
 
 
-class TestPositionAndSize:
-    """Test core.PictureShow._position_and_size"""
+class TestPictureBox:
+    """Test core.PictureShow._picture_box"""
 
     @pytest.mark.parametrize(
         'cell_size',
@@ -407,7 +407,7 @@ class TestPositionAndSize:
     )
     def test_big_wide_picture_fills_cell_x(self, cell_size):
         pic_width, pic_height = 800, 387
-        pic_box = PictureShow()._position_and_size(
+        pic_box = PictureShow()._picture_box(
             (pic_width, pic_height), cell_size, stretch_small=False, fill_cell=False
         )
         assert pic_box.x == 0
@@ -423,7 +423,7 @@ class TestPositionAndSize:
     )
     def test_big_tall_picture_fills_cell_y(self, cell_size):
         pic_width, pic_height = 400, 3260
-        pic_box = PictureShow()._position_and_size(
+        pic_box = PictureShow()._picture_box(
             (pic_width, pic_height), cell_size, stretch_small=False, fill_cell=False
         )
         assert pic_box.y == 0
@@ -432,7 +432,7 @@ class TestPositionAndSize:
 
     def test_small_picture_not_resized(self):
         pic_size = 320, 200
-        pic_box = PictureShow()._position_and_size(
+        pic_box = PictureShow()._picture_box(
             pic_size, DEFAULT_CELL, stretch_small=False, fill_cell=False
         )
         assert pic_box.size == pic_size
@@ -446,7 +446,7 @@ class TestPositionAndSize:
     )
     def test_small_wide_picture_stretch_small(self, cell_size):
         pic_width, pic_height = 192, 108
-        pic_box = PictureShow()._position_and_size(
+        pic_box = PictureShow()._picture_box(
             (pic_width, pic_height), cell_size, stretch_small=True, fill_cell=False
         )
         assert pic_box.x == 0
@@ -462,7 +462,7 @@ class TestPositionAndSize:
     )
     def test_small_tall_picture_stretch_small(self, cell_size):
         pic_width, pic_height = 68, 112
-        pic_box = PictureShow()._position_and_size(
+        pic_box = PictureShow()._picture_box(
             (pic_width, pic_height), cell_size, stretch_small=True, fill_cell=False
         )
         assert pic_box.y == 0
@@ -479,7 +479,7 @@ class TestPositionAndSize:
     )
     def test_fill_cell(self, pic_size):
         cell_size = DEFAULT_CELL
-        pic_box = PictureShow()._position_and_size(
+        pic_box = PictureShow()._picture_box(
             pic_size, cell_size, stretch_small=False, fill_cell=True
         )
         assert pic_box.position == (0, 0)


### PR DESCRIPTION
## Summary by Sourcery

Refactor the methods responsible for saving PDFs and positioning pictures to improve code clarity and maintainability. Rename '_save_pdf' to '_iter_save' and '_position_and_size' to '_picture_box' to better describe their functionalities. Update related test cases to reflect these changes.

Enhancements:
- Refactor the PDF saving method by renaming '_save_pdf' to '_iter_save' to better reflect its functionality as an iterator.
- Refactor the picture positioning method by renaming '_position_and_size' to '_picture_box' to clarify its purpose in calculating picture box dimensions.