### PR TITLE
Split CI workflow into separate jobs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: Build & test
+name: Test, build, publish
 
 on:
   push:
@@ -12,11 +12,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-test:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.10']
+    outputs:
+      version: ${{ steps.run_tests.outputs.VERSION }}
 
     steps:
     - name: Checkout
@@ -49,21 +51,54 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
       if: matrix.python-version == '3.13' && github.ref == 'refs/heads/main'
 
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
     - name: Build
       run: |
         pip install build
         python -m build
 
+    - name: Upload dist
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/
+        if-no-files-found: error
+        overwrite: true
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [test, build]
+    env:
+      VERSION: ${{ needs.test.outputs.version }}
+
+    steps:
+    - name: Download dist
+      uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist/
+
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: matrix.python-version == '3.13' && startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
 
     - name: Create GitHub release
       uses: softprops/action-gh-release@v2
-      if: matrix.python-version == '3.13' && startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: version ${{ steps.run_tests.outputs.VERSION }}
+        name: version ${{ env.VERSION }}
         files: 'dist/*'


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Split the "build-test" job into separate "test" and "build-publish" jobs. The "build-publish" job depends on the "test" job, ensuring that publishing only happens after tests pass.