### PR TITLE
Define available page sizes in backend class

### DIFF
--- a/src/pictureshow/backends.py
+++ b/src/pictureshow/backends.py
@@ -1,11 +1,18 @@
 import os
 
 from PIL import UnidentifiedImageError
+from reportlab.lib import pagesizes
 from reportlab.lib.utils import ImageReader
 from reportlab.pdfgen.canvas import Canvas
 
 
 class ReportlabBackend:
+    page_sizes = {
+        name: size
+        for name, size in vars(pagesizes).items()
+        if name.isupper()  # exclude deprecated names and function names
+    }
+
     read_errors = (
         OSError,  # file does not exist or is a dir
         UnidentifiedImageError,  # file not recognized as picture

--- a/src/pictureshow/cli.py
+++ b/src/pictureshow/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from platformdirs import user_cache_path
 
 from . import __version__
-from .core import PAGE_SIZES, PictureShow
+from .core import PictureShow
 
 CACHE_PATH = user_cache_path('pictureshow', ensure_exists=True)
 ERROR_LOG = CACHE_PATH / 'errors.log'
@@ -85,11 +85,11 @@ def _setup_parser():
     page_group.add_argument(
         '-p',
         '--page-size',
-        choices=PAGE_SIZES,
+        choices=PictureShow.page_sizes,
         default='A4',
         metavar='SIZE',
         help='specify page size; default is %(default)s '
-             f'(available sizes: {", ".join(PAGE_SIZES)})',
+             f'(available sizes: {", ".join(PictureShow.page_sizes)})',
     )
     page_group.add_argument(
         '-L',


### PR DESCRIPTION
## Summary by Sourcery

Define available page sizes in the backend class to allow for easier customization and to avoid a global constant.