### PR TITLE
Add support for PyPy 3.11

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.10', 'pypy3.11']
     outputs:
       version: ${{ steps.run_tests.outputs.VERSION }}
 

--- a/changelog.d/20250212_151902_michalportes1.md
+++ b/changelog.d/20250212_151902_michalportes1.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+- support for PyPy 3.11
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py{39,310,311,312,313}
 skip_missing_interpreters = true
 labels =
     python = py{39,310,311,312,313}
-    pypy = pypy310
+    pypy = pypy{310,311}
     code = code
 
 [testenv]


### PR DESCRIPTION
## Summary by Sourcery

Add support for PyPy 3.11 in the project's testing and build infrastructure

New Features:
- Add support for running tests on PyPy 3.11

CI:
- Update GitHub Actions workflow to include PyPy 3.11 in the test matrix
- Update tox configuration to support PyPy 3.11 testing

Chores:
- Add changelog fragment for PyPy 3.11 support