### PR TITLE
Define dependency groups for tests and coverage

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -40,9 +40,9 @@ jobs:
     - name: Run tests
       id: run_tests
       run: |
-        pip install .
+        pip install --upgrade pip
+        pip install --group=test --group=coverage .
         echo "VERSION=$(pictureshow --version)" >> $GITHUB_OUTPUT
-        pip install -r test-requirements.txt 'pytest-cov==6.*'
         pytest --cov --cov-report=xml --cov-report=term --verbose
 
     - name: Upload coverage to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,18 @@ pytest-mock = "^3"
 pytest-xdist = "^3"
 pypdf = "^5"
 
+[dependency-groups]
+test = [
+    "pytest==8.*",
+    "pytest-mock==3.*",
+    "pytest-xdist==3.*",
+    "pypdf==5.*",
+]
+coverage = [
+    "coverage==7.*",
+    "pytest-cov==6.*",
+]
+
 [tool.pytest.ini_options]
 addopts = "-ra --numprocesses=auto"
 xfail_strict = true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,0 @@
-pytest==8.*
-pytest-mock==3.*
-pytest-xdist==3.*
-pypdf==5.*

--- a/tox.ini
+++ b/tox.ini
@@ -7,18 +7,17 @@ labels =
     code = code
 
 [testenv]
-deps =
-    -r test-requirements.txt
+dependency_groups =
+    test
 commands =
     pytest {posargs}
 
 [testenv:coverage]
 description =
     Measure test coverage and generate HTML report. Pass `xml` or `lcov` to specify different format.
-deps =
-    {[testenv]deps}
-    coverage==7.*
-    pytest-cov==6.*
+dependency_groups =
+    test
+    coverage
 commands =
     pytest --cov --cov-report=xml --cov-report=term --verbose
     coverage {posargs:html}


### PR DESCRIPTION
- specify PEP 735 dependency groups in pyproject.toml
- use dependency groups in CI and tox jobs
- remove the `test-requirements.txt` file

## Summary by Sourcery

Introduce dependency groups for managing test and coverage dependencies.

Build:
- Define `test` and `coverage` dependency groups in `pyproject.toml`.
- Configure `tox` to install dependencies using the defined groups.
- Remove the obsolete `test-requirements.txt` file.

CI:
- Update the GitHub Actions workflow to install test and coverage dependencies using the defined groups.