### PR TITLE
Test on Python 3.14

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.10', 'pypy3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.10', 'pypy3.11']
     outputs:
       version: ${{ steps.run_tests.outputs.VERSION }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py{39,310,311,312,313}
+envlist = py{39,310,311,312,313,314}
 skip_missing_interpreters = true
 labels =
-    python = py{39,310,311,312,313}
+    python = py{39,310,311,312,313,314}
     pypy = pypy{310,311}
     code = code
 


### PR DESCRIPTION
## Summary by Sourcery

Enable testing on Python 3.14 across tox and GitHub Actions

Build:
- Add Python 3.14 to tox.ini envlist and labels

CI:
- Include Python 3.14 in the GitHub Actions test matrix